### PR TITLE
Use actual IP and TCP header lenght.

### DIFF
--- a/src/lib/recording.ts
+++ b/src/lib/recording.ts
@@ -79,29 +79,41 @@ function analyzePacket(context: Context): boolean {
 
         // If IPv4
         if (ethType === 0x0800) {
-            maxBytes = 20 + 14; // 20 bytes of IP header + 14 bytes of Ethernet header
-            // read protocol type
-            const protocolType = context.buffer[offset + 11];
-            if (protocolType === 6) {
-                maxBytes += 32; // 32 bytes of TCP header
-            } else if (protocolType === 17) {
-                maxBytes += 8; // 8 bytes of UDP header
-            } else if (protocolType === 1) {
-                // icmp
+            const ipHeaderStart = offset + 2;
+            const ipVersionAndIHL = context.buffer[ipHeaderStart];
+            const ipHeaderLength = (ipVersionAndIHL & 0x0F) * 4; // IHL field gives the length of the IP header
+
+            // read protocol type (TCP/UDP/ICMP/etc.)
+            const protocolType = context.buffer[ipHeaderStart + 9]; // Protocol field in IP header
+
+            if (protocolType === 6) { // TCP
+                const tcpHeaderStart = ipHeaderStart + ipHeaderLength;
+                const tcpOffsetAndFlags = context.buffer[tcpHeaderStart + 12];
+                const tcpHeaderLength = (tcpOffsetAndFlags >> 4) * 4; // Data offset in TCP header
+                maxBytes = ipHeaderLength + tcpHeaderLength + 14; // Total length: IP header + TCP header + Ethernet header
+            } else if (protocolType === 17) { // UDP
+                maxBytes = ipHeaderLength + 8 + 14; // IP header + 8 bytes UDP header + Ethernet header
+            } else if (protocolType === 1) { // ICMP
                 maxBytes = 0;
             } else {
                 maxBytes = 0;
             }
         } else if (ethTypeModified === 0x0800) {
-            maxBytes = 20 + 14 + 18; // 20 bytes of IP header + 14 bytes of Ethernet header
-            // read protocol type
-            const protocolType = context.buffer[offset + 11 + 18];
-            if (protocolType === 6) {
-                maxBytes += 32; // 32 bytes of TCP header
-            } else if (protocolType === 17) {
-                maxBytes += 8; // 8 bytes of UDP header
-            } else if (protocolType === 1) {
-                // icmp
+            const ipHeaderStart = offset + 2 + 18; // What is 18?
+            const ipVersionAndIHL = context.buffer[ipHeaderStart];
+            const ipHeaderLength = (ipVersionAndIHL & 0x0F) * 4; // IHL field gives the length of the IP header
+
+            // read protocol type (TCP/UDP/ICMP/etc.)
+            const protocolType = context.buffer[ipHeaderStart + 9]; // Protocol field in IP header
+
+            if (protocolType === 6) { // TCP
+                const tcpHeaderStart = ipHeaderStart + ipHeaderLength;
+                const tcpOffsetAndFlags = context.buffer[tcpHeaderStart + 12];
+                const tcpHeaderLength = (tcpOffsetAndFlags >> 4) * 4; // Data offset in TCP header
+                maxBytes = ipHeaderLength + tcpHeaderLength + 14 + 18; // Total length: IP header + TCP header + Ethernet header
+            } else if (protocolType === 17) { // UDP
+                maxBytes = ipHeaderLength + 8 + 14 + 18; // IP header + 8 bytes UDP header + Ethernet header
+            } else if (protocolType === 1) { // ICMP
                 maxBytes = 0;
             } else {
                 maxBytes = 0;


### PR DESCRIPTION
Checks the IHL field in the IP hheader and the Data offset in the TCP header for the actual header lenght.
 
Related to #49 